### PR TITLE
Add gitlab-runner to docker group.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,3 +19,4 @@ dependencies:
     gitlab_runner_concurrent: '{{ gpii_ci_worker_gitlab_runner_concurrent }}'
     gitlab_runner_registration_token: '{{ gpii_ci_worker_gitlab_runner_registration_token }}'
     gitlab_runner_list: '{{ gpii_ci_worker_gitlab_runner_list }}'
+  - docker

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,6 @@
 ---
 - src: https://github.com/DBLaci/ansible-gitlab-runner
   name: gitlab-runner
+
+- src: https://github.com/idi-ops/ansible-docker
+  name: docker

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,10 @@
 ---
+- name: Add gitlab-runner to docker group
+  user:
+    name: gitlab-runner
+    groups: docker
+    append: true
+
 - name: Configure git user.name for gitlab-runner
   git_config:
     name: user.name

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -62,6 +62,11 @@ def test_rake_installed_with_rvm(File, Sudo):
         assert File("/home/gitlab-runner/.rvm/gems/ruby-2.4.0/bin/rake").exists
 
 
+def test_docker_runs(Command, Sudo):
+    with Sudo("gitlab-runner"):
+        assert Command("docker images").rc == 0
+
+
 def test_git_configured(Command, Sudo):
     with Sudo("gitlab-runner"):
         # With Sudo() but without --git-dir, git tries to read pwd, doesn't


### PR DESCRIPTION
For https://issues.gpii.net/browse/GPII-2542, gitlab-runner needs to run docker so it can build and push the version-updater.