### PR TITLE
Switch to docker-ce.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,4 @@ dependencies:
     gitlab_runner_concurrent: '{{ gpii_ci_worker_gitlab_runner_concurrent }}'
     gitlab_runner_registration_token: '{{ gpii_ci_worker_gitlab_runner_registration_token }}'
     gitlab_runner_list: '{{ gpii_ci_worker_gitlab_runner_list }}'
-  - docker
+  - role: docker-ce

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,5 +2,5 @@
 - src: https://github.com/DBLaci/ansible-gitlab-runner
   name: gitlab-runner
 
-- src: https://github.com/idi-ops/ansible-docker
-  name: docker
+- src: https://github.com/idi-ops/ansible-docker-ce
+  name: docker-ce


### PR DESCRIPTION
This installs newer Docker, which we need for docker-compose and exekube (GPII-2974).