### PR TITLE
GPII-3141 - Require ansible-lint>=3.4.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible
+ansible-lint >= 3.4.22
 flake8
 molecule == 1.25.1
 python-vagrant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-ansible-lint >= 3.4.22
+ansible-lint >= 3.4.24
 flake8
 molecule == 1.25.1
 python-vagrant


### PR DESCRIPTION
v3.4.22 is the first version that doesn't show the error reported in GPII-3141

https://ci.gpii.net/job/ansible-nginx-common/272/console