### PR TITLE
GPII-3141 - Revert "GPII-3141 - Require ansible-lint>=3.4.24"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible
-ansible-lint >= 3.4.24
+ansible-lint >= 3.4.22
 flake8
 molecule == 1.25.1
 python-vagrant


### PR DESCRIPTION
This reverts commit d83f78e6f122573fc4eb26429df4189f7cfa7ef6.