### PR TITLE
Fix the behavior when the tar already exists

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -15,7 +15,7 @@ vagrant:
         memory: 256
         cpus: 1
   instances:
-    - name: ansible-gpii-ci-worker
+    - name: gpii-ci-worker
       ansible_groups:
         - group1
 verifier:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -112,8 +112,6 @@
     path: '/usr/local/bin/helm-{{ gpii_ci_worker_helm_version  }}-linux-amd64.tar.gz'
   register: helm_downloaded
 
-- debug:
-    var: helm_downloaded
 - name: Untar and install helm
   unarchive:
     src: '/usr/local/bin/helm-{{ gpii_ci_worker_helm_version }}-linux-amd64.tar.gz'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -106,14 +106,20 @@
     mode: 0440
     force: yes
   when: current_helm_version.rc is not defined or current_helm_version.rc != 0
+
+- name: Check if Helm package exists
+  stat:
+    path: '/usr/local/bin/helm-{{ gpii_ci_worker_helm_version  }}-linux-amd64.tar.gz'
   register: helm_downloaded
 
+- debug:
+    var: helm_downloaded
 - name: Untar and install helm
   unarchive:
     src: '/usr/local/bin/helm-{{ gpii_ci_worker_helm_version }}-linux-amd64.tar.gz'
     dest: /usr/local/bin/
     remote_src: True
-  when: helm_downloaded is changed
+  when: helm_downloaded.stat.exists
   tags: skip_ansible_lint  # [ANSIBLE0016] Tasks that run when changed should likely be handlers
 
 - name: Copy helm executable to bin directory
@@ -122,21 +128,19 @@
     src: /usr/local/bin/linux-amd64/helm
     dest: /usr/local/bin/helm
     mode: 0555
-  when: helm_downloaded is changed
+  when: helm_downloaded.stat.exists
   tags: skip_ansible_lint  # [ANSIBLE0016] Tasks that run when changed should likely be handlers
 
 - name: Remove helm unzipped directory
   file:
     path: /usr/local/bin/linux-amd64
     state: absent
-  when: helm_downloaded is changed
   tags: skip_ansible_lint  # [ANSIBLE0016] Tasks that run when changed should likely be handlers
 
 - name: Remove helm zip file
   file:
     path: "/usr/local/bin/helm-{{ gpii_ci_worker_helm_version  }}-linux-amd64.tar.gz"
     state: absent
-  when: helm_downloaded is changed
   tags: skip_ansible_lint  # [ANSIBLE0016] Tasks that run when changed should likely be handlers
 
 - name: Install pip


### PR DESCRIPTION
This patch solves the case where the tar.bz2 file is already downloaded.